### PR TITLE
added Sanitizer library; chapter attributes now includes menu heading

### DIFF
--- a/lib/polytexnic/book.rb
+++ b/lib/polytexnic/book.rb
@@ -68,7 +68,7 @@ class Polytexnic::Book
   end
 
   def chapter_attributes
-    chapters.map(&:marshal_dump)
+    chapters.map(&:to_hash)
   end
 
   def url

--- a/lib/polytexnic/book_manifest.rb
+++ b/lib/polytexnic/book_manifest.rb
@@ -30,6 +30,10 @@ class Polytexnic::BookManifest < OpenStruct
       html = Nokogiri::HTML(raw_html).at_css('p').inner_html
       chapter_number.zero? ? html : "Chapter #{chapter_number}: #{html}"
     end
+
+    def to_hash
+      marshal_dump.merge({ menu_heading: menu_heading })
+    end
   end
 
   class Section < OpenStruct

--- a/lib/polytexnic/sanitizer.rb
+++ b/lib/polytexnic/sanitizer.rb
@@ -1,0 +1,41 @@
+require 'sanitize'
+
+module Polytexnic
+  module Sanitizer
+    extend self
+
+    # Sanitization suitable for displaying untrusted generated html, while
+    # retaining useful tags and attributes.
+
+    def clean(html)
+      return unless html
+
+      sanitize_options = {
+        elements: %w{div span p a ul ol li h1 h2 h3
+          pre em sup table tbody thead tr td img},
+        remove_contents: %w{script},
+        attributes: {
+          'div' => %w{id class data-tralics-id data-number data-chapter},
+          'a'   => %w{id class href},
+          'span'=> %w{id class style},
+          'ol'  => %w{id class},
+          'ul'  => %w{id class},
+          'li'  => %w{id class},
+          'sup' => %w{id class},
+          'h1'  => %w{id class},
+          'h2'  => %w{id class},
+          'h3'  => %w{id class},
+          'img' => %w{id class src alt},
+          'em'  => %w{id class}
+        },
+        protocols: {
+          'a'   => {'href' => [:relative, 'http', 'https', 'mailto']},
+          'img' => {'src'  => [:relative, 'http', 'https']}
+        },
+        output: :xhtml
+      }
+
+      Sanitize.clean(html.force_encoding("UTF-8"), sanitize_options)
+    end
+  end
+end

--- a/lib/polytexnic/version.rb
+++ b/lib/polytexnic/version.rb
@@ -1,3 +1,3 @@
 module Polytexnic
-  VERSION = "0.4.6"
+  VERSION = "0.4.7"
 end

--- a/polytexnic.gemspec
+++ b/polytexnic.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'coffee-script'
   gem.add_dependency 'listen', '~> 1.3.1'
   gem.add_dependency 'rb-fsevent', '~> 0.9.3'
+  gem.add_dependency 'sanitize'
 end

--- a/spec/book_spec.rb
+++ b/spec/book_spec.rb
@@ -18,6 +18,16 @@ describe Polytexnic::Book do
 
       its(:slug) { should eq "book" }
       its(:url) { should match /\/books\/(.*?)\/redirect/ }
+
+      it "sets chapter attributes" do
+        expect(subject.chapter_attributes.first[:menu_heading]).
+          to match /Frontmatter/
+      end
+
+      it "has rendered latex in menu_heading" do
+        expect(subject.chapter_attributes.last[:menu_heading]).
+          to match /<em>/
+      end
     end
   end
 end

--- a/spec/sanitizer_spec.rb
+++ b/spec/sanitizer_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'polytexnic/sanitizer'
+
+describe Polytexnic::Sanitizer do
+  context "malicious html" do
+    let(:html) { "<div onclick='alert(document.cookie)'></div>"}
+
+    it "cleans xss vectors" do
+      expect(subject.clean(html)).to eq "<div></div>"
+    end
+  end
+
+  context "safe html" do
+    let(:html) do <<-EOS
+        <div id="a" class="b"></div>
+        <div data-tralics-id="c" data-number="d" data-chapter="e"></div>
+        <a id="a" class="b" href="c"></a>
+        <span id="a" class="b" style="c"></span>
+        <ol id="a" class="b"></ol>
+        <ul id="a" class="b"></ul>
+        <li id="a" class="b"></li>
+        <sup id="a" class="b"></sup>
+        <h1 id="a" class="b"></h1>
+        <h2 id="a" class="b"></h2>
+        <h3 id="a" class="b"></h3>
+        <img id="a" class="b" src="c" alt="d" />
+        <em id="a" class="b"></em>
+      EOS
+    end
+
+    it "allows class and id" do
+      expect(subject.clean(html)).to match html
+    end
+  end
+end


### PR DESCRIPTION
I pulled the Sanitizer to the gem since there's close parity between our pipeline's html output and what's safe to show on a site from an untrusted source. Also this way it can be included anywhere.

Also now we're submitting the rendered latex `menu_heading` to softcover, for use in chapter drop-downs, etc.

Version++
