### PR TITLE
Check for zip dependency.

### DIFF
--- a/lib/softcover/commands/check.rb
+++ b/lib/softcover/commands/check.rb
@@ -42,6 +42,7 @@ module Softcover
          [:kindlegen,   'KindleGen'],
          [:java,        'Java'],
          [:epubcheck,   'EpubCheck'],
+         [:zip,         'zip'],
         ]
       end
 
@@ -82,6 +83,8 @@ module Softcover
           message += "      ∟ Unzip EpubCheck into your home directory"
         when :inkscape
           message  = "Inkscape (http://inkscape.org/)"
+        when :zip
+          "zip (http://www.info-zip.org/)"
         else
           raise "Unknown label #{label}"
         end

--- a/lib/softcover/utils.rb
+++ b/lib/softcover/utils.rb
@@ -259,6 +259,8 @@ module Softcover::Utils
                    'inkscape'
       end
       filename
+    when :zip
+      `which zip`.chomp
     else
       raise "Unknown label #{label}"
     end


### PR DESCRIPTION
It is possible to install all other dependencies while missing the `zip` command.

If that happens, then you are not able to:

```
softcover build:epub
```

which gives error:

```
sh: 1: zip: not found
```

because EPUB is contained inside a zip.

Therefore, we must also check for `zip` as a dependency.
