### PR TITLE
Fix failing PDF fontsize verbatim test.

### DIFF
--- a/spec/builders/pdf_spec.rb
+++ b/spec/builders/pdf_spec.rb
@@ -39,7 +39,7 @@ describe Softcover::Builders::Pdf do
 
       it "should prepend the fontsize verbatim declaration for source code" do
         fontsize = '\begin{Verbatim}[fontsize=\relsize'
-        expect(File.read(Dir.glob('tmp/*.tmp.tex').first)).to include fontsize
+        expect(File.read(File.join('tmp', 'a_chapter.tmp.tex'))).to include fontsize
       end
 
       it "should replace the main file's \\includes with tmp files" do


### PR DESCRIPTION
The failure happens on unspecified behavior of `Dir.glob('*')` order.
The assertion can only pass for input files which contain a `\code{}` macro,
the only one of which is a_chapter.tex.

This is the same cause of failure of https://github.com/softcover/softcover/issues/102, but here it was simple to patch.
