### PR TITLE
added new feature to build pdf with option -nonstop

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ for a list of supported commands.
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
+
+###Local Development
+
+1. check out the fork
+2. add new feature
+3. build it localy with ```gem build softcover.gemspec```
+4. install the local version for using ```gem install softcover-1.0.beta2.gem```

--- a/lib/softcover/builders/pdf.rb
+++ b/lib/softcover/builders/pdf.rb
@@ -94,13 +94,19 @@ module Softcover
         # Returns the command to build the PDF (once).
         def build_pdf(book_filename, options={})
           tmp_filename = Softcover::Utils.tmpify(manifest, book_filename)
-          "#{xelatex} #{tmp_filename} #{options[:filters]}"
+          if options[:silent] || options[:quite]
+              "#{xelatex} --interaction=nonstopmode #{tmp_filename} #{options[:filters]}"
+          elsif options[:nonstop]
+              "#{xelatex} --interaction=nonstopmode #{tmp_filename} #{options[:filters]}"
+	  else
+              "#{xelatex} #{tmp_filename} #{options[:filters]}"
+          end
         end
 
         # Returns the full command to build the PDF.
         def pdf_cmd(book_filename, options={})
           if options[:once]
-            build_pdf(book_filename)
+            build_pdf(book_filename, options)
           elsif options[:'find-overfull']
             # The way we do things, code listings show up as "Overfull", but
             # they're actually fine, so filter them out.
@@ -115,7 +121,7 @@ module Softcover
                       filters: "| #{filter_out_listings} | #{show_context}" )
           else
             # Run the command twice (to guarantee up-to-date cross-references).
-            cmd = build_pdf(book_filename)
+            cmd = build_pdf(book_filename, options)
             "#{cmd} ; #{cmd}"
           end
         end

--- a/lib/softcover/cli.rb
+++ b/lib/softcover/cli.rb
@@ -41,6 +41,9 @@ module Softcover
         method_option :'find-overfull', aliases: '-f',
                                         desc: "Find overfull hboxes",
                                         type: :boolean
+        method_option :nonstop, aliases: '-n',
+                             desc: "Run PDF generator in nonstopmode",
+                             type: :boolean
       elsif format == 'mobi'
         method_option :kindlegen, aliases: '-k',
                                   desc: "Use KindleGen to build the MOBI",


### PR DESCRIPTION
Here is my promised pull request to support --interaction=nonstopmode for pdf build to make automated builds for softcover books more robust even if latex errors are present.