### PR TITLE
Ignore template top level tex file.

### DIFF
--- a/lib/softcover/template/gitignore
+++ b/lib/softcover/template/gitignore
@@ -3,6 +3,7 @@
 *.log
 *.toc
 *.out
+/*.tex
 *.tmp.*
 tmp/
 generated_polytex/


### PR DESCRIPTION
Ignore the `filename.tex` file on the toplevel of the template, as it is an output file generated from data on `Book.txt` and `config/book.yml` on `sc build`. Use glob because the exact filename is determined in `config/book.yml` and could be anything.
