### PR TITLE
Fix script type in lib/softcover/builders/utils/page.js

### DIFF
--- a/lib/softcover/book_manifest.rb
+++ b/lib/softcover/book_manifest.rb
@@ -136,9 +136,12 @@ class Softcover::BookManifest < OpenStruct
         chapter_title_regex = /^\s*\\chapter{(.*)}/
         content = File.read(File.join(polytex_dir, slug + '.tex'))
         chapter_title = content[chapter_title_regex, 1]
+        puts i
+        puts chapter_title
         j = 0
         sections = content.scan(/^\s*\\section{(.*)}/).flatten.map do |name|
           Section.new(name: name, section_number: j += 1)
+          # puts name
         end
         chapters.push Chapter.new(slug: slug,
                                   title: chapter_title,

--- a/lib/softcover/builders/epub.rb
+++ b/lib/softcover/builders/epub.rb
@@ -125,9 +125,13 @@ module Softcover
         File.write(path('epub/OEBPS/cover.html'), cover_page) if cover?
 
         pngs = []
+        puts chapters
         chapters.each_with_index do |chapter, i|
           target_filename = path("epub/OEBPS/#{chapter.fragment_name}")
+          puts target_filename
           File.open(target_filename, 'w') do |f|
+            #puts "writing html for file:"
+            #puts "#{chapter.fragment_name}"
             content = File.read(path("html/#{chapter.fragment_name}"))
             doc = strip_attributes(Nokogiri::HTML(content))
             body = doc.at_css('body')

--- a/lib/softcover/builders/html.rb
+++ b/lib/softcover/builders/html.rb
@@ -42,6 +42,8 @@ module Softcover
 
         if manifest.polytex?
           basename = File.basename(manifest.filename, '.tex')
+          # puts "In manifest polytex"
+          # puts basename
           @html  = converted_html(basename)
           @title = basename
           @mathjax = Softcover::Mathjax::config(chapter_number: false)
@@ -152,13 +154,16 @@ module Softcover
 
       # Splits the full XML document into chapters.
       def split_into_chapters(xml)
+        puts "In split into chapters .>>>>>>"
         chapter_number = 0
         current_chapter = manifest.chapters.first
         reference_cache = {}
         xml.css('#book>div').each do |node|
           klass = node.attributes['class'].to_s
+          #puts klass
           id = node.attributes['id'].to_s
           if klass == 'chapter' || id == 'frontmatter'
+            puts "Found a klass chapter"
             current_chapter = manifest.chapters[chapter_number]
             node['data-chapter'] = current_chapter.slug
             chapter_number += 1
@@ -170,6 +175,8 @@ module Softcover
           end
 
           current_chapter.nodes.push node
+          #puts "node="
+          #puts current_chapter.slug
         end
         reference_cache
       end

--- a/lib/softcover/builders/utils/page.js
+++ b/lib/softcover/builders/utils/page.js
@@ -57,6 +57,6 @@ page.open(system.args[1], function (status) {
       document.head.appendChild(script);
       // Time out after 60 seconds, which should be long enough for
       // almost all documents.
-      setTimeout(function () { alert("MathJax Timeout") }, 60000);
+      setTimeout(function () { alert("MathJax Timeout") }, 600000);
     });
 });

--- a/lib/softcover/builders/utils/page.js
+++ b/lib/softcover/builders/utils/page.js
@@ -52,7 +52,7 @@ page.open(system.args[1], function (status) {
 
     page.evaluate(function () {
       var script = document.createElement("script");
-      script.type = "text/x-mathjax-config";
+      script.type = "text/javascript";
       script.text = "MathJax.Hub.Queue([alert,'MathJax Done'])";
       document.head.appendChild(script);
       // Time out after 60 seconds, which should be long enough for

--- a/lib/softcover/mathjax.rb
+++ b/lib/softcover/mathjax.rb
@@ -24,12 +24,13 @@ module Softcover
           availableFonts: ["TeX"],
         },
         TeX: {
-          extensions: ["AMSmath.js", "AMSsymbols.js"],
+          extensions: ["cancel.js", "AMSmath.js", "AMSsymbols.js"],
           equationNumbers: {
             autoNumber: "AMS",
             #{fn}
           },
           Macros: {
+            texttt: ['{#1}',1],
             PolyTeX:    "Poly{\\\\TeX}",
             PolyTeXnic: "Poly{\\\\TeX}nic",
             #{custom_macros}


### PR DESCRIPTION
`x-mathjax-config` is only for MathJax settings, we need a generic `script/javascript` in order to run the Hub.Queue command.

Fixes  https://github.com/softcover/softcover/issues/127  for me.
