### PR TITLE
Pull Request to add additional install instructions for OS X Mavericks or Later

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ For more details about Softcover, see [*The Softcover Book*](http://manual.softc
 
     $ gem install softcover
 
+If installing on OS X Maverics or Later
+
+    $ gem install softcover -- --with-cppflags=-I/usr/local/opt/openssl/include
+
 ## Usage
 
 Run

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For more details about Softcover, see [*The Softcover Book*](http://manual.softc
 
     $ gem install softcover
 
-If installing on OS X Maverics or Later
+If installing on OS X Mavericks or Later
 
     $ gem install softcover -- --with-cppflags=-I/usr/local/opt/openssl/include
 


### PR DESCRIPTION
With the latest changes Apple has made by switching to TLS from OpenSSH, installing softcover with `gem install softcover` no longer successfully installs.  The problem stems from the compiler being unable to find the OpenSSH libraries.  Adding the `-- --with-cppflags=-I/usr/local/opt/openssl/include` flag solves this problem, but it may not be apparent to everyone attempting to install the gem.

I added an additional line to the README for those unaware souls and those looking for a solution.