### PR TITLE
First draft of veritcal-align math improvements

### DIFF
--- a/spec/builders/epub_spec.rb
+++ b/spec/builders/epub_spec.rb
@@ -172,6 +172,24 @@ describe Softcover::Builders::Epub do
         expect(path("epub/OEBPS/images/texmath")).to exist
         expect(Dir[path("epub/OEBPS/images/texmath/*.png")]).not_to be_empty
       end
+
+      it "should record vertical-align of inline math SVGs" do
+        content = File.read(path("./epub/OEBPS/a_chapter_fragment.xhtml"))
+        html = Nokogiri::HTML(content)
+        math_imgs = html.search('span.inline_math img')
+        math_imgs.each do |math_img|
+          expect(math_img['style']).to match /vertical-align/
+        end
+      end
+
+      it "should not add vertical-align to displayed math" do
+        content = File.read(path("./epub/OEBPS/a_chapter_fragment.xhtml"))
+        html = Nokogiri::HTML(content)
+        math_imgs = html.search('div.equation img')
+        math_imgs.each do |math_img|
+          expect(math_img['style']).not_to match /vertical-align/
+        end
+      end
     end
 
     it "should create the style files" do


### PR DESCRIPTION
  - Extract `vertical-align` style property from math SVGs
  - Convert lengths from ex units to em units (more likely to be supported)
      - used heuristic to find appropriate scaling factors for correct alignment
  - Changed scale factor of actual px to dpi conversion to 16 (up from 8)
  - Set style of math PNGs to appropriate height and vertical align (in ems, so will scale with CTRL+, CRTL-)

Remaining TODOs:

  1. the three conversion factors should be a config somewhere. Where?
      - height_scale_factor = 0.50  # 1ex/1em for scaling math PNG's height
      - valign_scale_factor = 0.45  # 1ex/1em when scaling math PNG's vertical-align
      - pt_scale_factor = 16  # 8 is OK, but let's do 16 for retina displays
  2. test settings work OK for varous ePub readers
  3. test on a higher-resolution kindle