### PR TITLE
softcover check doesn't notice epubcheck installation

### DIFF
--- a/lib/softcover/utils.rb
+++ b/lib/softcover/utils.rb
@@ -259,10 +259,7 @@ module Softcover::Utils
     when :calibre
       get_filename(:'ebook-convert')
     when :epubcheck
-      # Finds EpubCheck anywhere on the path.
-      version_3 = path('epubcheck-3.0/epubcheck-3.0.jar')
-      version_4 = path('epubcheck-4.0.1/epubcheck.jar')
-      first_path(version_4) || first_path(version_3) || ""
+      get_filename(:'epubcheck')
     when :inkscape
       default = '/Applications/Inkscape.app/Contents/Resources/bin/inkscape'
       filename_or_default(:inkscape, default)


### PR DESCRIPTION
epubcheck was falsely said to be unavailable when it had been installed via Homebrew