### PR TITLE
Two changes around SVG->PNG generation for texmath

### DIFF
--- a/spec/builders/epub_spec.rb
+++ b/spec/builders/epub_spec.rb
@@ -173,6 +173,12 @@ describe Softcover::Builders::Epub do
         expect(Dir[path("epub/OEBPS/images/texmath/*.png")]).not_to be_empty
       end
 
+      it "math PNGs shouldn't be too small (regression test for empty PNGs)" do
+        Dir[path("epub/OEBPS/images/texmath/*.png")].each do |pngfile|
+           expect(File.size(pngfile)).to be > 500
+        end
+      end
+
       it "should record vertical-align of inline math SVGs" do
         content = File.read(path("./epub/OEBPS/a_chapter_fragment.xhtml"))
         html = Nokogiri::HTML(content)


### PR DESCRIPTION
This PR:
  - Workaround for Inkscape 0.91 on Mac OS X
    - reads the `height` and `width` attributes form the MathJax SVG
      and appends them to the `style` attribute
      see: https://github.com/softcover/softcover/issues/154
      see: https://bugs.launchpad.net/inkscape/+bug/1634571

  - Removed uncessary correction factor `valign_in_ex += 0.1155`
    since MathJax no longer adds a 1px margin to SVG

It would be really cool if we can add a regression test—does anyone know of a way to check if a png file is empty?

