### PR TITLE
Remove fontenc

### DIFF
--- a/lib/softcover/article_template/latex_styles/softcover.sty
+++ b/lib/softcover/article_template/latex_styles/softcover.sty
@@ -49,11 +49,6 @@
 % Support strikethrough (via \sout{text})
 \usepackage[normalem]{ulem}
 
-% Configure fonts
-\renewcommand{\rmdefault}{ptm}
-\usepackage{courier}
-\normalfont % in case the EC fonts aren't available
-
 % Code environments
 \DefineVerbatimEnvironment%
   {code}{Verbatim}{fontsize=\relsize{-2.5},fontseries=b}

--- a/lib/softcover/article_template/latex_styles/softcover.sty
+++ b/lib/softcover/article_template/latex_styles/softcover.sty
@@ -9,8 +9,8 @@
 \setlength{\textwidth}{6.25in}
 \setlength{\topmargin}{0in}
 
-% Font encodings
-\usepackage[T1]{fontenc}
+% Font selection for XeTeX
+\usepackage{fontspec}
 % Be able to define colors
 \usepackage[svgnames]{xcolor}
 % Be able to include book covers

--- a/lib/softcover/book_template/Book.txt
+++ b/lib/softcover/book_template/Book.txt
@@ -7,3 +7,4 @@ mainmatter:
 a_chapter.md
 another_chapter.md
 yet_another_chapter.md
+# debug.md

--- a/lib/softcover/book_template/chapters/debug.md
+++ b/lib/softcover/book_template/chapters/debug.md
@@ -1,0 +1,7 @@
+# Debug
+
+## German Umlauts and Eszett
+
+Here are the [Umlauts](https://de.wikipedia.org/wiki/Umlaut#Umlaut_als_Bezeichnung_von_Buchstaben) lower case: äöü upper case: ÄÖÜ
+
+And [the letter Eszett](https://en.wikipedia.org/wiki/%C3%9F): ß

--- a/lib/softcover/book_template/latex_styles/softcover.sty
+++ b/lib/softcover/book_template/latex_styles/softcover.sty
@@ -49,11 +49,6 @@
 % Support strikethrough (via \sout{text})
 \usepackage[normalem]{ulem}
 
-% Configure fonts
-\renewcommand{\rmdefault}{ptm}
-\usepackage{courier}
-\normalfont % in case the EC fonts aren't available
-
 % Code environments
 \DefineVerbatimEnvironment%
   {code}{Verbatim}{fontsize=\relsize{-2.5},fontseries=b}

--- a/lib/softcover/book_template/latex_styles/softcover.sty
+++ b/lib/softcover/book_template/latex_styles/softcover.sty
@@ -9,8 +9,8 @@
 \setlength{\textwidth}{6.25in}
 \setlength{\topmargin}{0in}
 
-% Font encodings
-\usepackage[T1]{fontenc}
+% Font selection for XeTeX
+\usepackage{fontspec}
 % Be able to define colors
 \usepackage[svgnames]{xcolor}
 % Be able to include book covers


### PR DESCRIPTION
With `fontenc` I got problems displaying the german letter eszett (ß). Umlauts worked fine, but ß got shown as SS. It turns out that fontenc is not recommended for use with XeTeX, see for example http://tex.stackexchange.com/a/44701 and http://tex.stackexchange.com/questions/317382/how-to-change-the-fonts-of-this-document.

I've also removed the configure font section, everything seems to work well out of the box.

Includes a small debug chapter to show the problem.