### PR TITLE
Update gemspec to use latest curb

### DIFF
--- a/softcover.gemspec
+++ b/softcover.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activesupport', '~> 4.2.3'
   gem.add_dependency 'i18n', '~> 0.7.0'
   gem.add_dependency 'rest-client', '~> 1.8.0'
-  gem.add_dependency 'curb', '~> 0.8.5'
+  gem.add_dependency 'curb', '~> 0.9.7'
   gem.add_dependency 'ruby-progressbar', '~> 1.4.2'
   gem.add_dependency 'maruku', '~> 0.7.1'
   gem.add_dependency 'pygments.rb', '~> 1.2.1'


### PR DESCRIPTION
Older version of curb does not compile on latest Manjaro.