### PR TITLE
Fixed typo

### DIFF
--- a/lib/softcover/article_template/config/lang.yml
+++ b/lib/softcover/article_template/config/lang.yml
@@ -10,5 +10,5 @@ aside: Box
 listing: Listing
 equation: Equation
 eq: Eq
-frontmatter: Frontmatter
+frontmatter: Front Matter
 contents: Contents


### PR DESCRIPTION
Hey there :hand:, what a cool project! :+1:  Found a typo and thought I'd send a fix.

Front matter should be spelled with a space. https://en.wikipedia.org/wiki/Book_design#Front_matter
